### PR TITLE
Only show "Register" on NavBar if cms.regallowed is true

### DIFF
--- a/app/views/partials/navigation.blade.php
+++ b/app/views/partials/navigation.blade.php
@@ -53,11 +53,13 @@
                             Login
                         </a>
                     </li>
-                    <li {{ (Request::is('account/register') ? 'class="active"' : '') }}>
-                        <a href="{{ URL::route('account.register') }}">
-                            Register
-                        </a>
-                    </li>
+                    @if (Config::get('cms.regallowed'))
+                      <li {{ (Request::is('account/register') ? 'class="active"' : '') }}>
+                          <a href="{{ URL::route('account.register') }}">
+                              Register
+                          </a>
+                      </li>
+                    @endif
                 @endif
             </ul>
         </div>


### PR DESCRIPTION
Small change that only shows the Register button on the top navigation bar if "Enable Public Registration" is set to true in /app/config/cms.php configuration file.
