### PR TITLE
Add option for using Froala in blog posts

### DIFF
--- a/config/cms.php
+++ b/config/cms.php
@@ -88,6 +88,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Blog text editor
+    |--------------------------------------------------------------------------
+    |
+    | This defines which editor will be used for creating and editing blog posts.
+    |
+    | The available options are 'default' and 'fraola'. Please note that if you choose
+    | Fraola for legal reasons you will have to manually download it. Once you have,
+    | just put it in the assets folder in a folder called 'fraola'.
+    |
+    */
+    'editor' => 'default',
+
+    /*
+    |--------------------------------------------------------------------------
     | Comment Fetch Interval
     |--------------------------------------------------------------------------
     |

--- a/config/cms.php
+++ b/config/cms.php
@@ -95,7 +95,7 @@ return [
     |
     | The available options are 'default' and 'fraola'. Please note that if you choose
     | Fraola for legal reasons you will have to manually download it. Once you have,
-    | just put it in the assets folder in a folder called 'fraola'.
+    | just put it in the public/assets folder in a folder called 'fraola'.
     |
     */
     'editor' => 'default',

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -26,8 +26,14 @@
 {!! HTML::script('//cdnjs.cloudflare.com/ajax/libs/jquery-timeago/1.4.1/jquery.timeago.min.js') !!}
 {!! HTML::script('//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.0/js/bootstrap.min.js') !!}
 {!! Asset::scripts('main') !!}
+<script src="{!! asset('/assets/fraola/js/froala_editor.min.js') !!}"></script>
 @section('js')
 @show
 @if (Config::get('analytics.google'))
     @include('partials.analytics')
 @endif
+<script>
+    $(function() {
+        $('#edit').editable({inlineMode: false, height: 300})
+    });
+</script>

--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -4,6 +4,9 @@
 
 {!! HTML::style('//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.min.css') !!}
 {!! HTML::style('//cdnjs.cloudflare.com/ajax/libs/animate.css/3.2.0/animate.min.css') !!}
+<link href="/assets/fraola/css/font-awesome.min.css" rel="stylesheet" type="text/css" />
+<link href="/assets//fraola/css/froala_editor.min.css" rel="stylesheet" type="text/css" />
+  <link href="/assets/fraola/css/froala_style.min.css" rel="stylesheet" type="text/css" />
 {!! Asset::styles('main') !!}
 @section('css')
 @show

--- a/resources/views/posts/form.blade.php
+++ b/resources/views/posts/form.blade.php
@@ -19,7 +19,7 @@
     <div class="form-group{!! ($errors->has('body')) ? ' has-error' : '' !!}">
         <label class="col-md-2 col-sm-3 col-xs-10 control-label" for="body">Post Body</label>
         <div class="col-lg-6 col-md-8 col-sm-9 col-xs-12">
-            <textarea name="body" type="text" class="form-control" data-provide="markdown" placeholder="Post Body" rows="10">{!! Request::old('body', $form['defaults']['body']) !!}</textarea>
+            <textarea name="body" type="text" class="form-control" id="edit" placeholder="Post Body" rows="10">{!! Request::old('body', $form['defaults']['body']) !!}</textarea>
             {!! ($errors->has('body') ? $errors->first('body') : '') !!}
         </div>
     </div>


### PR DESCRIPTION
Can't legally put Froala in the github. That is unless I pay $299 for the open-source licence. I think not. Otherwise pretty solid, easy to build and no bugs. I realize there are some inconsistencies in the way we link to assets, I just don't quite understand the way @GrahamCampbell does it.
![screen shot 2015-01-12 at 9 05 07 pm](https://cloud.githubusercontent.com/assets/5386772/5715450/b588de6e-9a9e-11e4-99f3-00655508ee75.png)
