### PR TITLE
Use USA style date time when adding/editing events

### DIFF
--- a/resources/assets/js/cms-picker.js
+++ b/resources/assets/js/cms-picker.js
@@ -1,5 +1,5 @@
 $(document).ready(function() {
     $('#datetimepicker1').datetimepicker({
-        pick12HourFormat: false
+        format: 'D/M/YYYY HH:mm'
     });
 });

--- a/resources/views/events/form.blade.php
+++ b/resources/views/events/form.blade.php
@@ -20,7 +20,7 @@
         <label class="col-md-2 col-sm-3 col-xs-10 control-label" for="date">Event Date</label>
         <div class="col-lg-3 col-md-4 col-sm-5 col-xs-10">
             <div class="input-group date" id="datetimepicker1">
-                <input name="date" value="{!! Request::old('date', $form['defaults']['date']) !!}" type='text' class="form-control" placeholder="Event Date" data-format="DD/MM/YYYY HH:mm">
+                <input name="date" value="{!! Request::old('date', $form['defaults']['date']) !!}" type='text' class="form-control" placeholder="Event Date">
                 <span class="input-group-addon"><span class="fa fa-calendar fa-fw"></span></span>
             </div>
         </div>


### PR DESCRIPTION
The datepicker seems to want to use the format "MM/DD/YYYY HH/MM PP".
I changed the php to format the date like that for adding and editing events.