### PR TITLE
Changed unique index on email to include delete_at

### DIFF
--- a/database/migrations/2016_03_15_120418_modify_unique_email_index_users_table.php
+++ b/database/migrations/2016_03_15_120418_modify_unique_email_index_users_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ModifyUniqueEmailIndexUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique('users_email_unique');
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->unique(['email', 'deleted_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+      Schema::table('users', function (Blueprint $table) {
+          $table->dropUnique('users_email_unique');
+      });
+
+      Schema::table('users', function (Blueprint $table) {
+          $table->unique('email');
+      });
+    }
+}


### PR DESCRIPTION
Changed unique index on email to combined unique index based on both email and deleted_at  so that deleted users can be added to system again. Otherwise it don't let create user if that email address exist even for deleted users